### PR TITLE
Update capabilities access calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ function defaultPathBuilder(spec, descriptions, results, capabilities) {
  */
 function structuredPathBuilder(spec, descriptions, results, capabilities) {
 	// Only the major browser version
-	var browserVersion = capabilities.caps_.version.substring(0, capabilities.caps_.version.indexOf('.') || capabilities.caps_.version.length);
-	var pathStr = capabilities.caps_.platform + path.sep + capabilities.caps_.browserName + path.sep + 
+	var browserVersion = capabilities.get('version').substring(0, capabilities.get('version').indexOf('.') || capabilities.get('version').length);
+	var pathStr = capabilities.get('platform') + path.sep + capabilities.get('browserName') + path.sep +
 			browserVersion + path.sep; + util.generateGuid();
 	var filename = descriptions.join('_');
 	return (pathStr + path.sep + filename).toLowerCase();
@@ -69,10 +69,10 @@ function defaultMetaDataBuilder(spec, descriptions, results, capabilities) {
 	var metaData = {
 			description: descriptions.reverse().join(' ')
 			, passed: results.passedExpectations
-			, os: capabilities.caps_.platform
+			, os: capabilities.get('platform')
 			, browser: {
-				name: capabilities.caps_.browserName
-				, version: capabilities.caps_.version
+				name: capabilities.get('browserName')
+				, version: capabilities.get('version')
 			}
 		};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-screenshot-reporter",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Use the screenshot reporter to capture screenshots from your Selenium nodes after each executed Protractor test case.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Update the calls to use the newer selenium style per https://github.com/angular/protractor/issues/3036

Unsure if you still use this, but I had forked yours to use in my project, and just needed to make this small change to get it working on the newest version of all the libraries.
